### PR TITLE
Potentially fixed the bugs for invalid Email types and about page in …

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -43,7 +43,7 @@ const Footer = () => {
                       key={i}
                       className="text-[14px] cursor-pointer hover:text-richblack-50 transition-all duration-200"
                     >
-                      <Link to={ele.toLowerCase()}>{ele}</Link>
+                      <Link to={ `/${ele.toLowerCase()}`}>{ele}</Link>
                     </div>
                   );
                 })}

--- a/src/components/core/auth/SignupForm.jsx
+++ b/src/components/core/auth/SignupForm.jsx
@@ -115,7 +115,7 @@ export default function SignupForm() {
           </p>
           <input
             required
-            type="text"
+            type="email"
             name="email"
             value={formData.email}
             onChange={changeHandler}


### PR DESCRIPTION
This commit fixes the issue #68 
# Issue Title: Invalid email types bug and footer about us page link fix

## Type of change ☑️

What sort of change have you made:

Ive added email type as 'email' in place of text.
Changed the src of link in footer page to link to the correct about us page


 
## How Has This Been Tested? ⚙️
Ive tested it by running the front end only and testing it manually.
